### PR TITLE
Add sidebar project categories

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Collision } from "@dnd-kit/core";
 
 import {
   createThreadJumpHintVisibilityController,
@@ -11,6 +12,7 @@ import {
   hasUnseenCompletion,
   isContextMenuPointerDown,
   orderItemsByPreferredIds,
+  prioritizeProjectDropCollisions,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
@@ -42,6 +44,10 @@ function makeLatestTurn(overrides?: {
     startedAt: overrides?.startedAt ?? "2026-03-09T10:00:00.000Z",
     completedAt: overrides?.completedAt ?? "2026-03-09T10:05:00.000Z",
   };
+}
+
+function makeCollision(id: string): Collision {
+  return { id };
 }
 
 describe("hasUnseenCompletion", () => {
@@ -119,6 +125,38 @@ describe("createThreadJumpHintVisibilityController", () => {
     vi.advanceTimersByTime(THREAD_JUMP_HINT_SHOW_DELAY_MS);
 
     expect(visibilityChanges).toEqual([]);
+  });
+});
+
+describe("prioritizeProjectDropCollisions", () => {
+  it("prefers category targets over the dragged project itself", () => {
+    expect(
+      prioritizeProjectDropCollisions({
+        collisions: [makeCollision("project-a"), makeCollision("project-category:apps")],
+        activeId: "project-a",
+        isCategoryCollision: (id) => String(id).startsWith("project-category:"),
+      }),
+    ).toEqual([makeCollision("project-category:apps")]);
+  });
+
+  it("drops the active project collision when another project target exists", () => {
+    expect(
+      prioritizeProjectDropCollisions({
+        collisions: [makeCollision("project-a"), makeCollision("project-b")],
+        activeId: "project-a",
+        isCategoryCollision: (id) => String(id).startsWith("project-category:"),
+      }),
+    ).toEqual([makeCollision("project-b")]);
+  });
+
+  it("keeps the active collision when it is the only available target", () => {
+    expect(
+      prioritizeProjectDropCollisions({
+        collisions: [makeCollision("project-a")],
+        activeId: "project-a",
+        isCategoryCollision: (id) => String(id).startsWith("project-category:"),
+      }),
+    ).toEqual([makeCollision("project-a")]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { Collision, UniqueIdentifier } from "@dnd-kit/core";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
@@ -239,6 +240,26 @@ export function orderItemsByPreferredIds<TItem, TId>(input: {
   });
   const remaining = items.filter((item) => !preferredIdSet.has(getId(item)));
   return [...ordered, ...remaining];
+}
+
+export function prioritizeProjectDropCollisions(input: {
+  collisions: readonly Collision[];
+  activeId: UniqueIdentifier;
+  isCategoryCollision: (id: UniqueIdentifier) => boolean;
+}): Collision[] {
+  if (input.collisions.length === 0) {
+    return [];
+  }
+
+  const nonActiveCollisions = input.collisions.filter(
+    (collision) => collision.id !== input.activeId,
+  );
+  const candidateCollisions =
+    nonActiveCollisions.length > 0 ? nonActiveCollisions : [...input.collisions];
+  const categoryCollisions = candidateCollisions.filter((collision) =>
+    input.isCategoryCollision(collision.id),
+  );
+  return categoryCollisions.length > 0 ? categoryCollisions : candidateCollisions;
 }
 
 export function getVisibleSidebarThreadIds<TThreadId>(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -152,6 +152,7 @@ import {
   getSidebarThreadIdsToPrewarm,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
+  prioritizeProjectDropCollisions,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
@@ -3230,12 +3231,20 @@ export default function Sidebar() {
     }),
   );
   const projectCollisionDetection = useCallback<CollisionDetection>((args) => {
-    const pointerCollisions = pointerWithin(args);
+    const pointerCollisions = prioritizeProjectDropCollisions({
+      collisions: pointerWithin(args),
+      activeId: args.active.id,
+      isCategoryCollision: (id) => parseProjectCategoryDropId(id) !== null,
+    });
     if (pointerCollisions.length > 0) {
       return pointerCollisions;
     }
 
-    return closestCorners(args);
+    return prioritizeProjectDropCollisions({
+      collisions: closestCorners(args),
+      activeId: args.active.id,
+      isCategoryCollision: (id) => parseProjectCategoryDropId(id) !== null,
+    });
   }, []);
 
   const handleProjectDragEnd = useCallback(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,6 +3,8 @@ import {
   ArrowUpDownIcon,
   ChevronRightIcon,
   CloudIcon,
+  FolderIcon,
+  FolderPlusIcon,
   GitPullRequestIcon,
   PlusIcon,
   SearchIcon,
@@ -29,6 +31,7 @@ import {
   type DragStartEvent,
   closestCorners,
   pointerWithin,
+  useDroppable,
   useSensor,
   useSensors,
   type DragEndEvent,
@@ -61,7 +64,7 @@ import { usePrimaryEnvironmentId } from "../environments/primary";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
 import { isTerminalFocused } from "../lib/terminalFocus";
-import { isMacPlatform, newCommandId } from "../lib/utils";
+import { cn, isMacPlatform, newCommandId } from "../lib/utils";
 import {
   selectProjectByRef,
   selectProjectsAcrossEnvironments,
@@ -133,6 +136,7 @@ import {
   SidebarFooter,
   SidebarGroup,
   SidebarHeader,
+  SidebarMenuAction,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -178,6 +182,14 @@ import {
   type SidebarProjectGroupMember,
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
+import {
+  buildSidebarProjectCategoryTree,
+  canAssignSidebarProjectCategoryParent,
+  orderSidebarProjectCategories,
+  resolveSidebarProjectCategoryId,
+  type SidebarProjectCategory,
+  type SidebarProjectCategoryNode,
+} from "../sidebarProjectCategories";
 const THREAD_PREVIEW_LIMIT = 6;
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
@@ -198,6 +210,21 @@ const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> =
   repository_path: "Group by repository path",
   separate: "Keep separate",
 };
+const CATEGORY_DROP_ID_PREFIX = "project-category:";
+
+function projectCategoryDropId(categoryId: string): string {
+  return `${CATEGORY_DROP_ID_PREFIX}${categoryId}`;
+}
+
+function parseProjectCategoryDropId(value: string | number): string | null {
+  const normalized = String(value);
+  if (!normalized.startsWith(CATEGORY_DROP_ID_PREFIX)) {
+    return null;
+  }
+
+  const categoryId = normalized.slice(CATEGORY_DROP_ID_PREFIX.length).trim();
+  return categoryId.length > 0 ? categoryId : null;
+}
 
 function threadJumpLabelMapsEqual(
   left: ReadonlyMap<string, string>,
@@ -942,6 +969,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     sidebarProjectGroupingOverrides: settings.sidebarProjectGroupingOverrides,
   }));
   const { updateSettings } = useUpdateSettings();
+  const projectCategories = useUiStateStore((state) => state.projectCategories);
+  const projectCategoryAssignmentsByPhysicalKey = useUiStateStore(
+    (state) => state.projectCategoryAssignmentsByPhysicalKey,
+  );
+  const projectCategoryOrder = useUiStateStore((state) => state.projectCategoryOrder);
+  const assignProjectsToCategory = useUiStateStore((state) => state.assignProjectsToCategory);
   const router = useRouter();
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
   const toggleProject = useUiStateStore((state) => state.toggleProject);
@@ -1093,6 +1126,43 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     }
     return counts;
   }, [memberProjectByScopedKey, project.memberProjects, projectThreads]);
+  const orderedProjectCategories = useMemo(
+    () => orderSidebarProjectCategories(projectCategories, projectCategoryOrder),
+    [projectCategories, projectCategoryOrder],
+  );
+  const categoryPathLabelById = useMemo(() => {
+    const categoryById = new Map(
+      orderedProjectCategories.map((category) => [category.id, category] as const),
+    );
+
+    const readLabel = (categoryId: string): string => {
+      const category = categoryById.get(categoryId);
+      if (!category) {
+        return categoryId;
+      }
+
+      const segments = [category.name];
+      let parentId = category.parentId;
+      while (parentId) {
+        const parent = categoryById.get(parentId);
+        if (!parent) {
+          break;
+        }
+        segments.unshift(parent.name);
+        parentId = parent.parentId;
+      }
+
+      return segments.join(" / ");
+    };
+
+    return new Map(
+      orderedProjectCategories.map((category) => [category.id, readLabel(category.id)] as const),
+    );
+  }, [orderedProjectCategories]);
+  const resolvedProjectCategoryId = useMemo(
+    () => resolveSidebarProjectCategoryId(project, projectCategoryAssignmentsByPhysicalKey),
+    [project, projectCategoryAssignmentsByPhysicalKey],
+  );
 
   const { projectStatus, visibleProjectThreads, orderedProjectThreadKeys } = useMemo(() => {
     const lastVisitedAtByThreadKey = new Map(
@@ -1422,10 +1492,33 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           };
         };
 
+        const projectCategoryMenuItems: ContextMenuItem<string>[] =
+          orderedProjectCategories.length > 0 || resolvedProjectCategoryId !== null
+            ? [
+                {
+                  id: "project-category:submenu",
+                  label: "Project category",
+                  children: [
+                    {
+                      id: "project-category:none",
+                      label: "No category",
+                      ...(resolvedProjectCategoryId === null ? { disabled: true } : {}),
+                    },
+                    ...orderedProjectCategories.map((category) => ({
+                      id: `project-category:${category.id}`,
+                      label: categoryPathLabelById.get(category.id) ?? category.name,
+                      ...(resolvedProjectCategoryId === category.id ? { disabled: true } : {}),
+                    })),
+                  ],
+                },
+              ]
+            : [];
+
         const clicked = await api.contextMenu.show(
           [
             buildTargetedItem("rename", "Rename project"),
             buildTargetedItem("grouping", "Project grouping…"),
+            ...projectCategoryMenuItems,
             buildTargetedItem("copy-path", "Copy Project Path"),
             buildTargetedItem("delete", "Remove project", {
               destructive: true,
@@ -1443,17 +1536,40 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           return;
         }
 
+        if (clicked === "project-category:none") {
+          assignProjectsToCategory(
+            project.memberProjects.map((member) => member.physicalProjectKey),
+            null,
+          );
+          return;
+        }
+
+        const clickedProjectCategoryId = clicked.startsWith("project-category:")
+          ? clicked.slice("project-category:".length)
+          : null;
+        if (clickedProjectCategoryId && clickedProjectCategoryId !== "submenu") {
+          assignProjectsToCategory(
+            project.memberProjects.map((member) => member.physicalProjectKey),
+            clickedProjectCategoryId,
+          );
+          return;
+        }
+
         await actionHandlers.get(clicked)?.();
       })();
     },
     [
+      assignProjectsToCategory,
+      categoryPathLabelById,
       copyPathToClipboard,
       handleRemoveProject,
       memberThreadCountByPhysicalKey,
       openProjectGroupingDialog,
       openProjectRenameDialog,
+      orderedProjectCategories,
       project.groupedProjectCount,
       project.memberProjects,
+      resolvedProjectCategoryId,
       suppressProjectClickForContextMenuRef,
     ],
   );
@@ -2139,6 +2255,114 @@ const SidebarProjectListRow = memo(function SidebarProjectListRow(props: Sidebar
   );
 });
 
+const SidebarProjectCategoryRow = memo(function SidebarProjectCategoryRow(props: {
+  node: SidebarProjectCategoryNode;
+  isManualProjectSorting: boolean;
+  onCreateSubcategory: (parentId: string) => void;
+  onEditCategory: (category: SidebarProjectCategory) => void;
+  onDeleteCategory: (category: SidebarProjectCategory) => void;
+  children?: React.ReactNode;
+}) {
+  const {
+    children,
+    isManualProjectSorting,
+    node,
+    onCreateSubcategory,
+    onDeleteCategory,
+    onEditCategory,
+  } = props;
+  const setProjectCategoryExpanded = useUiStateStore((state) => state.setProjectCategoryExpanded);
+  const categoryExpanded = useUiStateStore(
+    (state) => state.projectCategoryExpandedById[node.category.id] ?? true,
+  );
+  const { setNodeRef, isOver } = useDroppable({
+    id: projectCategoryDropId(node.category.id),
+    disabled: !isManualProjectSorting,
+  });
+
+  const handleCategoryContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      void (async () => {
+        const api = readLocalApi();
+        if (!api) {
+          return;
+        }
+
+        const clicked = await api.contextMenu.show(
+          [
+            { id: "new-subcategory", label: "New subcategory" },
+            { id: "edit", label: "Edit category" },
+            { id: "delete", label: "Delete category", destructive: true },
+          ],
+          {
+            x: event.clientX,
+            y: event.clientY,
+          },
+        );
+
+        if (clicked === "new-subcategory") {
+          onCreateSubcategory(node.category.id);
+          return;
+        }
+
+        if (clicked === "edit") {
+          onEditCategory(node.category);
+          return;
+        }
+
+        if (clicked === "delete") {
+          onDeleteCategory(node.category);
+        }
+      })();
+    },
+    [node.category, onCreateSubcategory, onDeleteCategory, onEditCategory],
+  );
+
+  return (
+    <SidebarMenuItem className="rounded-md">
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "relative rounded-md",
+          isManualProjectSorting && isOver && "ring-1 ring-primary/40",
+        )}
+      >
+        <SidebarMenuButton
+          size="sm"
+          className="gap-2 px-2 py-1.5 text-left hover:bg-accent hover:text-sidebar-accent-foreground"
+          onClick={() => setProjectCategoryExpanded(node.category.id, !categoryExpanded)}
+          onContextMenu={handleCategoryContextMenu}
+        >
+          <ChevronRightIcon
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150",
+              categoryExpanded && "rotate-90",
+            )}
+          />
+          <FolderIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+          <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground/90">
+            {node.category.name}
+          </span>
+          <span className="shrink-0 text-[10px] text-muted-foreground/60">{node.projectCount}</span>
+        </SidebarMenuButton>
+        <SidebarMenuAction
+          showOnHover
+          className="top-1 right-1"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onCreateSubcategory(node.category.id);
+          }}
+        >
+          <FolderPlusIcon className="size-3.5" />
+        </SidebarMenuAction>
+      </div>
+      {categoryExpanded && children ? <SidebarMenuSub>{children}</SidebarMenuSub> : null}
+    </SidebarMenuItem>
+  );
+});
+
 function T3Wordmark() {
   return (
     <svg
@@ -2371,6 +2595,10 @@ interface SidebarProjectsContentProps {
   updateSettings: ReturnType<typeof useUpdateSettings>["updateSettings"];
   openAddProject: () => void;
   isManualProjectSorting: boolean;
+  projectCategories: readonly SidebarProjectCategory[];
+  projectCategoryOrder: readonly string[];
+  rootProjectCategories: readonly SidebarProjectCategoryNode[];
+  uncategorizedProjects: readonly SidebarProjectSnapshot[];
   projectDnDSensors: ReturnType<typeof useSensors>;
   projectCollisionDetection: CollisionDetection;
   handleProjectDragStart: (event: DragStartEvent) => void;
@@ -2411,6 +2639,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     updateSettings,
     openAddProject,
     isManualProjectSorting,
+    projectCategories,
+    projectCategoryOrder,
+    rootProjectCategories,
+    uncategorizedProjects,
     projectDnDSensors,
     projectCollisionDetection,
     handleProjectDragStart,
@@ -2435,6 +2667,19 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     attachProjectListAutoAnimateRef,
     projectsLength,
   } = props;
+  const addProjectCategory = useUiStateStore((state) => state.addProjectCategory);
+  const updateProjectCategoryState = useUiStateStore((state) => state.updateProjectCategory);
+  const deleteProjectCategoryState = useUiStateStore((state) => state.deleteProjectCategory);
+  const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
+  const [categoryDialogTarget, setCategoryDialogTarget] = useState<SidebarProjectCategory | null>(
+    null,
+  );
+  const [categoryDialogName, setCategoryDialogName] = useState("");
+  const [categoryDialogParentId, setCategoryDialogParentId] = useState<string | "root">("root");
+  const orderedProjectCategories = useMemo(
+    () => orderSidebarProjectCategories(projectCategories, projectCategoryOrder),
+    [projectCategories, projectCategoryOrder],
+  );
 
   const handleProjectSortOrderChange = useCallback(
     (sortOrder: SidebarProjectSortOrder) => {
@@ -2454,6 +2699,146 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     },
     [updateSettings],
   );
+  const openCreateCategoryDialog = useCallback((parentId: string | null = null) => {
+    setCategoryDialogOpen(true);
+    setCategoryDialogTarget(null);
+    setCategoryDialogName("");
+    setCategoryDialogParentId(parentId ?? "root");
+  }, []);
+  const openEditCategoryDialog = useCallback((category: SidebarProjectCategory) => {
+    setCategoryDialogOpen(true);
+    setCategoryDialogTarget(category);
+    setCategoryDialogName(category.name);
+    setCategoryDialogParentId(category.parentId ?? "root");
+  }, []);
+  const closeCategoryDialog = useCallback(() => {
+    setCategoryDialogOpen(false);
+    setCategoryDialogTarget(null);
+    setCategoryDialogName("");
+    setCategoryDialogParentId("root");
+  }, []);
+  const submitCategoryDialog = useCallback(() => {
+    const name = categoryDialogName.trim();
+    if (!name) {
+      toastManager.add({
+        type: "warning",
+        title: "Category name cannot be empty",
+      });
+      return;
+    }
+
+    const parentId = categoryDialogParentId === "root" ? null : categoryDialogParentId;
+    if (categoryDialogTarget) {
+      updateProjectCategoryState({
+        id: categoryDialogTarget.id,
+        name,
+        parentId,
+      });
+    } else {
+      addProjectCategory({
+        name,
+        parentId,
+      });
+    }
+
+    closeCategoryDialog();
+  }, [
+    addProjectCategory,
+    categoryDialogName,
+    categoryDialogParentId,
+    categoryDialogTarget,
+    closeCategoryDialog,
+    updateProjectCategoryState,
+  ]);
+  const deleteCategory = useCallback(
+    async (category: SidebarProjectCategory) => {
+      const api = readLocalApi();
+      if (!api) {
+        return;
+      }
+
+      const confirmed = await api.dialogs.confirm(
+        [
+          `Delete category "${category.name}"?`,
+          "Child categories move up one level and assigned projects move to the parent category.",
+        ].join("\n"),
+      );
+      if (!confirmed) {
+        return;
+      }
+
+      deleteProjectCategoryState(category.id);
+    },
+    [deleteProjectCategoryState],
+  );
+  const availableCategoryParents = useMemo(
+    () =>
+      orderedProjectCategories.filter((category) =>
+        categoryDialogTarget
+          ? canAssignSidebarProjectCategoryParent({
+              categories: projectCategories,
+              categoryId: categoryDialogTarget.id,
+              parentId: category.id,
+            })
+          : true,
+      ),
+    [categoryDialogTarget, orderedProjectCategories, projectCategories],
+  );
+
+  const renderProjectRow = (project: SidebarProjectSnapshot) => {
+    const sharedProps: SidebarProjectItemProps = {
+      project,
+      isThreadListExpanded: expandedThreadListsByProject.has(project.projectKey),
+      activeRouteThreadKey: activeRouteProjectKey === project.projectKey ? routeThreadKey : null,
+      newThreadShortcutLabel,
+      handleNewThread,
+      archiveThread,
+      deleteThread,
+      threadJumpLabelByKey,
+      attachThreadListAutoAnimateRef,
+      expandThreadListForProject,
+      collapseThreadListForProject,
+      dragInProgressRef,
+      suppressProjectClickAfterDragRef,
+      suppressProjectClickForContextMenuRef,
+      isManualProjectSorting,
+      dragHandleProps: null,
+    };
+
+    if (!isManualProjectSorting) {
+      return <SidebarProjectListRow key={project.projectKey} {...sharedProps} />;
+    }
+
+    return (
+      <SortableProjectItem key={project.projectKey} projectId={project.projectKey}>
+        {(dragHandleProps) => (
+          <SidebarProjectItem {...sharedProps} dragHandleProps={dragHandleProps} />
+        )}
+      </SortableProjectItem>
+    );
+  };
+
+  const renderCategoryNode = (node: SidebarProjectCategoryNode): React.ReactNode => {
+    const categoryChildren = [
+      ...node.children.map(renderCategoryNode),
+      ...node.projects.map(renderProjectRow),
+    ];
+
+    return (
+      <SidebarProjectCategoryRow
+        key={node.category.id}
+        node={node}
+        isManualProjectSorting={isManualProjectSorting}
+        onCreateSubcategory={(parentId) => openCreateCategoryDialog(parentId)}
+        onEditCategory={openEditCategoryDialog}
+        onDeleteCategory={(category) => {
+          void deleteCategory(category);
+        }}
+      >
+        {categoryChildren}
+      </SidebarProjectCategoryRow>
+    );
+  };
 
   return (
     <SidebarContent className="gap-0">
@@ -2522,6 +2907,21 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 render={
                   <button
                     type="button"
+                    aria-label="Add category"
+                    className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+                    onClick={() => openCreateCategoryDialog(null)}
+                  />
+                }
+              >
+                <FolderPlusIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="right">Add category</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
                     aria-label="Add project"
                     data-testid="sidebar-add-project-trigger"
                     className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
@@ -2550,62 +2950,15 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 items={sortedProjects.map((project) => project.projectKey)}
                 strategy={verticalListSortingStrategy}
               >
-                {sortedProjects.map((project) => (
-                  <SortableProjectItem key={project.projectKey} projectId={project.projectKey}>
-                    {(dragHandleProps) => (
-                      <SidebarProjectItem
-                        project={project}
-                        isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
-                        activeRouteThreadKey={
-                          activeRouteProjectKey === project.projectKey ? routeThreadKey : null
-                        }
-                        newThreadShortcutLabel={newThreadShortcutLabel}
-                        handleNewThread={handleNewThread}
-                        archiveThread={archiveThread}
-                        deleteThread={deleteThread}
-                        threadJumpLabelByKey={threadJumpLabelByKey}
-                        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
-                        expandThreadListForProject={expandThreadListForProject}
-                        collapseThreadListForProject={collapseThreadListForProject}
-                        dragInProgressRef={dragInProgressRef}
-                        suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
-                        suppressProjectClickForContextMenuRef={
-                          suppressProjectClickForContextMenuRef
-                        }
-                        isManualProjectSorting={isManualProjectSorting}
-                        dragHandleProps={dragHandleProps}
-                      />
-                    )}
-                  </SortableProjectItem>
-                ))}
+                {rootProjectCategories.map(renderCategoryNode)}
+                {uncategorizedProjects.map(renderProjectRow)}
               </SortableContext>
             </SidebarMenu>
           </DndContext>
         ) : (
           <SidebarMenu ref={attachProjectListAutoAnimateRef}>
-            {sortedProjects.map((project) => (
-              <SidebarProjectListRow
-                key={project.projectKey}
-                project={project}
-                isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
-                activeRouteThreadKey={
-                  activeRouteProjectKey === project.projectKey ? routeThreadKey : null
-                }
-                newThreadShortcutLabel={newThreadShortcutLabel}
-                handleNewThread={handleNewThread}
-                archiveThread={archiveThread}
-                deleteThread={deleteThread}
-                threadJumpLabelByKey={threadJumpLabelByKey}
-                attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
-                expandThreadListForProject={expandThreadListForProject}
-                collapseThreadListForProject={collapseThreadListForProject}
-                dragInProgressRef={dragInProgressRef}
-                suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
-                suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
-                isManualProjectSorting={isManualProjectSorting}
-                dragHandleProps={null}
-              />
-            ))}
+            {rootProjectCategories.map(renderCategoryNode)}
+            {uncategorizedProjects.map(renderProjectRow)}
           </SidebarMenu>
         )}
 
@@ -2614,6 +2967,76 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             No projects yet
           </div>
         )}
+        <Dialog
+          open={categoryDialogOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              closeCategoryDialog();
+            }
+          }}
+        >
+          <DialogPopup className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle>{categoryDialogTarget ? "Edit category" : "New category"}</DialogTitle>
+              <DialogDescription>
+                {categoryDialogTarget
+                  ? "Update the category label or move it under a different parent."
+                  : "Create a sidebar category for organizing projects."}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogPanel className="space-y-4">
+              <div className="grid gap-1.5">
+                <span className="text-xs font-medium text-foreground">Category name</span>
+                <Input
+                  aria-label="Category name"
+                  value={categoryDialogName}
+                  onChange={(event) => setCategoryDialogName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      submitCategoryDialog();
+                    }
+                  }}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <span className="text-xs font-medium text-foreground">Parent category</span>
+                <Select
+                  value={categoryDialogParentId}
+                  onValueChange={(value) => {
+                    setCategoryDialogParentId(value ?? "root");
+                  }}
+                >
+                  <SelectTrigger className="w-full" aria-label="Category parent">
+                    <SelectValue>
+                      {categoryDialogParentId === "root"
+                        ? "Top level"
+                        : (orderedProjectCategories.find(
+                            (category) => category.id === categoryDialogParentId,
+                          )?.name ?? "Top level")}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup align="end" alignItemWithTrigger={false}>
+                    <SelectItem hideIndicator value="root">
+                      Top level
+                    </SelectItem>
+                    {availableCategoryParents.map((category) => (
+                      <SelectItem key={category.id} hideIndicator value={category.id}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+              </div>
+            </DialogPanel>
+            <DialogFooter>
+              <Button variant="outline" onClick={closeCategoryDialog}>
+                Cancel
+              </Button>
+              <Button onClick={submitCategoryDialog}>Save</Button>
+            </DialogFooter>
+          </DialogPopup>
+        </Dialog>
       </SidebarGroup>
     </SidebarContent>
   );
@@ -2623,7 +3046,13 @@ export default function Sidebar() {
   const projects = useStore(useShallow(selectProjectsAcrossEnvironments));
   const sidebarThreads = useStore(useShallow(selectSidebarThreadsAcrossEnvironments));
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
+  const projectCategories = useUiStateStore((store) => store.projectCategories);
+  const projectCategoryAssignmentsByPhysicalKey = useUiStateStore(
+    (store) => store.projectCategoryAssignmentsByPhysicalKey,
+  );
+  const projectCategoryOrder = useUiStateStore((store) => store.projectCategoryOrder);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const assignProjectsToCategory = useUiStateStore((store) => store.assignProjectsToCategory);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
@@ -2819,15 +3248,34 @@ export default function Sidebar() {
       const { active, over } = event;
       if (!over || active.id === over.id) return;
       const activeProject = sidebarProjects.find((project) => project.projectKey === active.id);
-      const overProject = sidebarProjects.find((project) => project.projectKey === over.id);
-      if (!activeProject || !overProject) return;
+      if (!activeProject) return;
       const activeMemberKeys = activeProject.memberProjects.map(
         (member) => member.physicalProjectKey,
       );
+
+      const overCategoryId = parseProjectCategoryDropId(over.id);
+      if (overCategoryId) {
+        assignProjectsToCategory(activeMemberKeys, overCategoryId);
+        return;
+      }
+
+      const overProject = sidebarProjects.find((project) => project.projectKey === over.id);
+      if (!overProject) return;
+
       const overMemberKeys = overProject.memberProjects.map((member) => member.physicalProjectKey);
+      const overProjectCategoryId =
+        resolveSidebarProjectCategoryId(overProject, projectCategoryAssignmentsByPhysicalKey) ??
+        null;
+      assignProjectsToCategory(activeMemberKeys, overProjectCategoryId);
       reorderProjects(activeMemberKeys, overMemberKeys);
     },
-    [sidebarProjectSortOrder, reorderProjects, sidebarProjects],
+    [
+      assignProjectsToCategory,
+      projectCategoryAssignmentsByPhysicalKey,
+      reorderProjects,
+      sidebarProjectSortOrder,
+      sidebarProjects,
+    ],
   );
 
   const handleProjectDragStart = useCallback(
@@ -2898,6 +3346,21 @@ export default function Sidebar() {
     sidebarProjects,
     visibleThreads,
   ]);
+  const { rootCategories, uncategorizedProjects } = useMemo(
+    () =>
+      buildSidebarProjectCategoryTree({
+        categories: projectCategories,
+        categoryOrder: projectCategoryOrder,
+        projects: sortedProjects,
+        categoryByPhysicalProjectKey: projectCategoryAssignmentsByPhysicalKey,
+      }),
+    [
+      projectCategories,
+      projectCategoryAssignmentsByPhysicalKey,
+      projectCategoryOrder,
+      sortedProjects,
+    ],
+  );
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(
     () =>
@@ -3302,6 +3765,10 @@ export default function Sidebar() {
             updateSettings={updateSettings}
             openAddProject={openAddProjectCommandPalette}
             isManualProjectSorting={isManualProjectSorting}
+            projectCategories={projectCategories}
+            projectCategoryOrder={projectCategoryOrder}
+            rootProjectCategories={rootCategories}
+            uncategorizedProjects={uncategorizedProjects}
             projectDnDSensors={projectDnDSensors}
             projectCollisionDetection={projectCollisionDetection}
             handleProjectDragStart={handleProjectDragStart}

--- a/apps/web/src/sidebarProjectCategories.test.ts
+++ b/apps/web/src/sidebarProjectCategories.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import { EnvironmentId, ProjectId } from "@t3tools/contracts";
+
+import {
+  buildSidebarProjectCategoryTree,
+  canAssignSidebarProjectCategoryParent,
+  resolveSidebarProjectCategoryId,
+  type SidebarProjectCategory,
+} from "./sidebarProjectCategories";
+import type { SidebarProjectSnapshot } from "./sidebarProjectGrouping";
+
+const primaryEnvironmentId = EnvironmentId.make("env-primary");
+
+function makeProjectSnapshot(
+  overrides: Partial<SidebarProjectSnapshot> & Pick<SidebarProjectSnapshot, "id" | "name" | "cwd">,
+): SidebarProjectSnapshot {
+  return {
+    id: overrides.id,
+    environmentId: primaryEnvironmentId,
+    name: overrides.name,
+    cwd: overrides.cwd,
+    projectKey: overrides.projectKey ?? `${primaryEnvironmentId}:${overrides.cwd}`,
+    displayName: overrides.displayName ?? overrides.name,
+    groupedProjectCount: overrides.groupedProjectCount ?? 1,
+    environmentPresence: overrides.environmentPresence ?? "local-only",
+    memberProjects: overrides.memberProjects ?? [
+      {
+        id: overrides.id,
+        environmentId: primaryEnvironmentId,
+        name: overrides.name,
+        cwd: overrides.cwd,
+        scripts: [],
+        defaultModelSelection: null,
+        physicalProjectKey: overrides.projectKey ?? `${primaryEnvironmentId}:${overrides.cwd}`,
+        environmentLabel: null,
+      },
+    ],
+    memberProjectRefs: overrides.memberProjectRefs ?? [],
+    remoteEnvironmentLabels: overrides.remoteEnvironmentLabels ?? [],
+    scripts: overrides.scripts ?? [],
+    defaultModelSelection: overrides.defaultModelSelection ?? null,
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.updatedAt,
+    repositoryIdentity: overrides.repositoryIdentity ?? null,
+  };
+}
+
+describe("sidebarProjectCategories", () => {
+  it("resolves a shared category only when all grouped members agree", () => {
+    const project = makeProjectSnapshot({
+      id: ProjectId.make("project-1"),
+      name: "project-1",
+      cwd: "/repo/project-1",
+      projectKey: "project-1",
+      groupedProjectCount: 2,
+      memberProjects: [
+        {
+          id: ProjectId.make("project-1a"),
+          environmentId: primaryEnvironmentId,
+          name: "project-1a",
+          cwd: "/repo/project-1a",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "physical-1a",
+          environmentLabel: null,
+        },
+        {
+          id: ProjectId.make("project-1b"),
+          environmentId: primaryEnvironmentId,
+          name: "project-1b",
+          cwd: "/repo/project-1b",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "physical-1b",
+          environmentLabel: null,
+        },
+      ],
+    });
+
+    expect(
+      resolveSidebarProjectCategoryId(project, {
+        "physical-1a": "cat-apps",
+        "physical-1b": "cat-apps",
+      }),
+    ).toBe("cat-apps");
+
+    expect(
+      resolveSidebarProjectCategoryId(project, {
+        "physical-1a": "cat-apps",
+        "physical-1b": "cat-tools",
+      }),
+    ).toBeNull();
+  });
+
+  it("builds nested category trees and leaves mixed projects uncategorized", () => {
+    const categories: SidebarProjectCategory[] = [
+      { id: "cat-apps", name: "Apps", parentId: null },
+      { id: "cat-mobile", name: "Mobile", parentId: "cat-apps" },
+      { id: "cat-tools", name: "Tools", parentId: null },
+    ];
+    const website = makeProjectSnapshot({
+      id: ProjectId.make("website"),
+      name: "website",
+      cwd: "/repo/website",
+      projectKey: "website",
+      memberProjects: [
+        {
+          id: ProjectId.make("website-1"),
+          environmentId: primaryEnvironmentId,
+          name: "website-1",
+          cwd: "/repo/website-1",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "website-1",
+          environmentLabel: null,
+        },
+      ],
+    });
+    const mobile = makeProjectSnapshot({
+      id: ProjectId.make("mobile"),
+      name: "mobile",
+      cwd: "/repo/mobile",
+      projectKey: "mobile",
+      memberProjects: [
+        {
+          id: ProjectId.make("mobile-1"),
+          environmentId: primaryEnvironmentId,
+          name: "mobile-1",
+          cwd: "/repo/mobile-1",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "mobile-1",
+          environmentLabel: null,
+        },
+      ],
+    });
+    const mixed = makeProjectSnapshot({
+      id: ProjectId.make("mixed"),
+      name: "mixed",
+      cwd: "/repo/mixed",
+      projectKey: "mixed",
+      groupedProjectCount: 2,
+      memberProjects: [
+        {
+          id: ProjectId.make("mixed-1"),
+          environmentId: primaryEnvironmentId,
+          name: "mixed-1",
+          cwd: "/repo/mixed-1",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "mixed-1",
+          environmentLabel: null,
+        },
+        {
+          id: ProjectId.make("mixed-2"),
+          environmentId: primaryEnvironmentId,
+          name: "mixed-2",
+          cwd: "/repo/mixed-2",
+          scripts: [],
+          defaultModelSelection: null,
+          physicalProjectKey: "mixed-2",
+          environmentLabel: null,
+        },
+      ],
+    });
+
+    const result = buildSidebarProjectCategoryTree({
+      categories,
+      categoryOrder: ["cat-apps", "cat-mobile", "cat-tools"],
+      projects: [website, mobile, mixed],
+      categoryByPhysicalProjectKey: {
+        "website-1": "cat-apps",
+        "mobile-1": "cat-mobile",
+        "mixed-1": "cat-apps",
+        "mixed-2": "cat-tools",
+      },
+    });
+
+    expect(result.rootCategories.map((node) => node.category.id)).toEqual([
+      "cat-apps",
+      "cat-tools",
+    ]);
+    expect(result.rootCategories[0]?.projects.map((project) => project.projectKey)).toEqual([
+      "website",
+    ]);
+    expect(result.rootCategories[0]?.children.map((node) => node.category.id)).toEqual([
+      "cat-mobile",
+    ]);
+    expect(
+      result.rootCategories[0]?.children[0]?.projects.map((project) => project.projectKey),
+    ).toEqual(["mobile"]);
+    expect(result.uncategorizedProjects.map((project) => project.projectKey)).toEqual(["mixed"]);
+  });
+
+  it("rejects assigning a category to one of its descendants", () => {
+    const categories: SidebarProjectCategory[] = [
+      { id: "cat-parent", name: "Parent", parentId: null },
+      { id: "cat-child", name: "Child", parentId: "cat-parent" },
+      { id: "cat-grandchild", name: "Grandchild", parentId: "cat-child" },
+    ];
+
+    expect(
+      canAssignSidebarProjectCategoryParent({
+        categories,
+        categoryId: "cat-parent",
+        parentId: "cat-grandchild",
+      }),
+    ).toBe(false);
+    expect(
+      canAssignSidebarProjectCategoryParent({
+        categories,
+        categoryId: "cat-child",
+        parentId: "cat-parent",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats cyclic category parents as top-level categories", () => {
+    const categories: SidebarProjectCategory[] = [
+      { id: "cat-a", name: "A", parentId: "cat-b" },
+      { id: "cat-b", name: "B", parentId: "cat-a" },
+    ];
+
+    const result = buildSidebarProjectCategoryTree({
+      categories,
+      categoryOrder: ["cat-a", "cat-b"],
+      projects: [],
+      categoryByPhysicalProjectKey: {},
+    });
+
+    expect(result.rootCategories.map((node) => node.category.id)).toEqual(["cat-a", "cat-b"]);
+  });
+});

--- a/apps/web/src/sidebarProjectCategories.ts
+++ b/apps/web/src/sidebarProjectCategories.ts
@@ -1,0 +1,212 @@
+import type { SidebarProjectSnapshot } from "./sidebarProjectGrouping";
+
+export interface SidebarProjectCategory {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
+export interface SidebarProjectCategoryNode {
+  category: SidebarProjectCategory;
+  children: SidebarProjectCategoryNode[];
+  projects: SidebarProjectSnapshot[];
+  projectCount: number;
+}
+
+const SORT_LOCALE_OPTIONS: Intl.CollatorOptions = { numeric: true, sensitivity: "base" };
+
+function compareByName(left: { name: string }, right: { name: string }): number {
+  return left.name.localeCompare(right.name, undefined, SORT_LOCALE_OPTIONS);
+}
+
+function uniqueNonEmptyValues(values: ReadonlyArray<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    unique.push(trimmed);
+  }
+
+  return unique;
+}
+
+function finalizeSidebarProjectCategoryNode(
+  node: SidebarProjectCategoryNode,
+): SidebarProjectCategoryNode {
+  const children = node.children.map(finalizeSidebarProjectCategoryNode);
+  const projectCount =
+    node.projects.length + children.reduce((count, child) => count + child.projectCount, 0);
+
+  return {
+    ...node,
+    children,
+    projectCount,
+  };
+}
+
+export function orderSidebarProjectCategories(
+  categories: ReadonlyArray<SidebarProjectCategory>,
+  categoryOrder: ReadonlyArray<string>,
+): SidebarProjectCategory[] {
+  if (categories.length <= 1) {
+    return [...categories];
+  }
+
+  const orderIndexById = new Map(categoryOrder.map((id, index) => [id, index] as const));
+
+  return [...categories].toSorted((left, right) => {
+    const leftOrderIndex = orderIndexById.get(left.id);
+    const rightOrderIndex = orderIndexById.get(right.id);
+
+    if (leftOrderIndex !== undefined || rightOrderIndex !== undefined) {
+      return (
+        (leftOrderIndex ?? Number.POSITIVE_INFINITY) - (rightOrderIndex ?? Number.POSITIVE_INFINITY)
+      );
+    }
+
+    return compareByName(left, right);
+  });
+}
+
+export function resolveSidebarProjectCategoryId(
+  project: SidebarProjectSnapshot,
+  categoryByPhysicalProjectKey: Readonly<Record<string, string>>,
+): string | null {
+  const categoryIds = uniqueNonEmptyValues(
+    project.memberProjects.map((member) => categoryByPhysicalProjectKey[member.physicalProjectKey]),
+  );
+
+  return categoryIds.length === 1 ? categoryIds[0]! : null;
+}
+
+export function isSidebarProjectCategoryAncestor(input: {
+  categories: ReadonlyArray<SidebarProjectCategory>;
+  ancestorId: string;
+  categoryId: string;
+}): boolean {
+  const parentIdByCategoryId = new Map(
+    input.categories.map((category) => [category.id, category.parentId] as const),
+  );
+
+  const visitedCategoryIds = new Set<string>();
+  let parentId = parentIdByCategoryId.get(input.categoryId) ?? null;
+  while (parentId) {
+    if (visitedCategoryIds.has(parentId)) {
+      return false;
+    }
+    visitedCategoryIds.add(parentId);
+
+    if (parentId === input.ancestorId) {
+      return true;
+    }
+    parentId = parentIdByCategoryId.get(parentId) ?? null;
+  }
+
+  return false;
+}
+
+export function canAssignSidebarProjectCategoryParent(input: {
+  categories: ReadonlyArray<SidebarProjectCategory>;
+  categoryId: string;
+  parentId: string | null;
+}): boolean {
+  if (!input.parentId) {
+    return true;
+  }
+
+  if (input.parentId === input.categoryId) {
+    return false;
+  }
+
+  return !isSidebarProjectCategoryAncestor({
+    categories: input.categories,
+    ancestorId: input.categoryId,
+    categoryId: input.parentId,
+  });
+}
+
+export function buildSidebarProjectCategoryTree(input: {
+  categories: ReadonlyArray<SidebarProjectCategory>;
+  categoryOrder: ReadonlyArray<string>;
+  projects: ReadonlyArray<SidebarProjectSnapshot>;
+  categoryByPhysicalProjectKey: Readonly<Record<string, string>>;
+}): {
+  rootCategories: SidebarProjectCategoryNode[];
+  uncategorizedProjects: SidebarProjectSnapshot[];
+  projectCategoryByProjectKey: Map<string, string | null>;
+} {
+  const orderedCategories = orderSidebarProjectCategories(input.categories, input.categoryOrder);
+  const categoryById = new Map(
+    orderedCategories.map((category) => [category.id, category] as const),
+  );
+  const nodeById = new Map<string, SidebarProjectCategoryNode>(
+    orderedCategories.map((category) => [
+      category.id,
+      {
+        category,
+        children: [],
+        projects: [],
+        projectCount: 0,
+      },
+    ]),
+  );
+
+  const projectCategoryByProjectKey = new Map<string, string | null>();
+  const uncategorizedProjects: SidebarProjectSnapshot[] = [];
+
+  for (const project of input.projects) {
+    const categoryId = resolveSidebarProjectCategoryId(project, input.categoryByPhysicalProjectKey);
+    const resolvedCategoryId = categoryId && categoryById.has(categoryId) ? categoryId : null;
+    projectCategoryByProjectKey.set(project.projectKey, resolvedCategoryId);
+
+    if (!resolvedCategoryId) {
+      uncategorizedProjects.push(project);
+      continue;
+    }
+
+    nodeById.get(resolvedCategoryId)?.projects.push(project);
+  }
+
+  const rootCategories: SidebarProjectCategoryNode[] = [];
+  for (const category of orderedCategories) {
+    const node = nodeById.get(category.id);
+    if (!node) {
+      continue;
+    }
+
+    const validParentId =
+      category.parentId &&
+      categoryById.has(category.parentId) &&
+      canAssignSidebarProjectCategoryParent({
+        categories: orderedCategories,
+        categoryId: category.id,
+        parentId: category.parentId,
+      })
+        ? category.parentId
+        : null;
+
+    if (!validParentId) {
+      rootCategories.push(node);
+      continue;
+    }
+
+    const parentNode = nodeById.get(validParentId);
+    if (!parentNode) {
+      rootCategories.push(node);
+      continue;
+    }
+
+    parentNode.children.push(node);
+  }
+
+  return {
+    rootCategories: rootCategories.map(finalizeSidebarProjectCategoryNode),
+    uncategorizedProjects,
+    projectCategoryByProjectKey,
+  };
+}

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -2,13 +2,18 @@ import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
+  addProjectCategory,
+  assignProjectsToCategory,
   clearThreadUi,
+  deleteProjectCategory,
   markThreadUnread,
   reorderProjects,
+  setProjectCategoryExpanded,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
   syncProjects,
   syncThreads,
+  updateProjectCategory,
   type UiState,
 } from "./uiStateStore";
 
@@ -16,6 +21,10 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
     projectOrder: [],
+    projectCategories: [],
+    projectCategoryAssignmentsByPhysicalKey: {},
+    projectCategoryExpandedById: {},
+    projectCategoryOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     ...overrides,
@@ -297,6 +306,109 @@ describe("uiStateStore pure functions", () => {
 
     expect(next.projectExpandedById[project1]).toBe(false);
     expect(next.projectOrder).toEqual([project1]);
+  });
+
+  it("addProjectCategory appends a new category and keeps its order stable", () => {
+    const initialState = makeUiState({
+      projectCategories: [{ id: "cat-apps", name: "Apps", parentId: null }],
+      projectCategoryOrder: ["cat-apps"],
+    });
+
+    const next = addProjectCategory(initialState, {
+      id: "cat-mobile",
+      name: "Mobile",
+      parentId: "cat-apps",
+    });
+
+    expect(next.projectCategories).toEqual([
+      { id: "cat-apps", name: "Apps", parentId: null },
+      { id: "cat-mobile", name: "Mobile", parentId: "cat-apps" },
+    ]);
+    expect(next.projectCategoryOrder).toEqual(["cat-apps", "cat-mobile"]);
+  });
+
+  it("updateProjectCategory rejects cyclic parents by moving the category to the top level", () => {
+    const initialState = makeUiState({
+      projectCategories: [
+        { id: "cat-parent", name: "Parent", parentId: null },
+        { id: "cat-child", name: "Child", parentId: "cat-parent" },
+      ],
+      projectCategoryOrder: ["cat-parent", "cat-child"],
+    });
+
+    const next = updateProjectCategory(initialState, {
+      id: "cat-parent",
+      name: "Parent",
+      parentId: "cat-child",
+    });
+
+    expect(next.projectCategories).toEqual([
+      { id: "cat-parent", name: "Parent", parentId: null },
+      { id: "cat-child", name: "Child", parentId: "cat-parent" },
+    ]);
+  });
+
+  it("deleteProjectCategory reparents children and moves assignments to the parent", () => {
+    const initialState = makeUiState({
+      projectCategories: [
+        { id: "cat-apps", name: "Apps", parentId: null },
+        { id: "cat-mobile", name: "Mobile", parentId: "cat-apps" },
+        { id: "cat-ios", name: "iOS", parentId: "cat-mobile" },
+      ],
+      projectCategoryAssignmentsByPhysicalKey: {
+        "project-1": "cat-mobile",
+        "project-2": "cat-ios",
+      },
+      projectCategoryExpandedById: {
+        "cat-mobile": false,
+        "cat-ios": false,
+      },
+      projectCategoryOrder: ["cat-apps", "cat-mobile", "cat-ios"],
+    });
+
+    const next = deleteProjectCategory(initialState, "cat-mobile");
+
+    expect(next.projectCategories).toEqual([
+      { id: "cat-apps", name: "Apps", parentId: null },
+      { id: "cat-ios", name: "iOS", parentId: "cat-apps" },
+    ]);
+    expect(next.projectCategoryAssignmentsByPhysicalKey).toEqual({
+      "project-1": "cat-apps",
+      "project-2": "cat-ios",
+    });
+    expect(next.projectCategoryExpandedById).toEqual({
+      "cat-ios": false,
+    });
+    expect(next.projectCategoryOrder).toEqual(["cat-apps", "cat-ios"]);
+  });
+
+  it("assignProjectsToCategory sets and clears physical project assignments", () => {
+    const initialState = makeUiState({
+      projectCategories: [{ id: "cat-apps", name: "Apps", parentId: null }],
+    });
+
+    const assigned = assignProjectsToCategory(initialState, ["project-1", "project-2"], "cat-apps");
+    expect(assigned.projectCategoryAssignmentsByPhysicalKey).toEqual({
+      "project-1": "cat-apps",
+      "project-2": "cat-apps",
+    });
+
+    const cleared = assignProjectsToCategory(assigned, ["project-1"], null);
+    expect(cleared.projectCategoryAssignmentsByPhysicalKey).toEqual({
+      "project-2": "cat-apps",
+    });
+  });
+
+  it("setProjectCategoryExpanded stores only collapsed overrides", () => {
+    const initialState = makeUiState();
+
+    const collapsed = setProjectCategoryExpanded(initialState, "cat-apps", false);
+    expect(collapsed.projectCategoryExpandedById).toEqual({
+      "cat-apps": false,
+    });
+
+    const expanded = setProjectCategoryExpanded(collapsed, "cat-apps", true);
+    expect(expanded.projectCategoryExpandedById).toEqual({});
   });
 
   it("clearThreadUi removes visit state for deleted threads", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,5 +1,9 @@
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
+import {
+  canAssignSidebarProjectCategoryParent,
+  type SidebarProjectCategory,
+} from "./sidebarProjectCategories";
 
 const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
 const LEGACY_PERSISTED_STATE_KEYS = [
@@ -18,12 +22,20 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
+  projectCategories?: SidebarProjectCategory[];
+  projectCategoryAssignmentsByPhysicalKey?: Record<string, string>;
+  projectCategoryExpandedById?: Record<string, boolean>;
+  projectCategoryOrder?: string[];
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
 }
 
 export interface UiProjectState {
   projectExpandedById: Record<string, boolean>;
   projectOrder: string[];
+  projectCategories: SidebarProjectCategory[];
+  projectCategoryAssignmentsByPhysicalKey: Record<string, string>;
+  projectCategoryExpandedById: Record<string, boolean>;
+  projectCategoryOrder: string[];
 }
 
 export interface UiThreadState {
@@ -46,6 +58,10 @@ export interface SyncThreadInput {
 const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
+  projectCategories: [],
+  projectCategoryAssignmentsByPhysicalKey: {},
+  projectCategoryExpandedById: {},
+  projectCategoryOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
 };
@@ -74,8 +90,22 @@ function readPersistedState(): UiState {
     }
     const parsed = JSON.parse(raw) as PersistedUiState;
     hydratePersistedProjectState(parsed);
+    const projectCategories = sanitizePersistedProjectCategories(parsed.projectCategories);
     return {
       ...initialState,
+      projectCategories,
+      projectCategoryAssignmentsByPhysicalKey: normalizeProjectCategoryAssignments(
+        projectCategories,
+        sanitizePersistedProjectCategoryAssignments(parsed.projectCategoryAssignmentsByPhysicalKey),
+      ),
+      projectCategoryExpandedById: normalizeProjectCategoryExpanded(
+        projectCategories,
+        sanitizePersistedProjectCategoryExpanded(parsed.projectCategoryExpandedById),
+      ),
+      projectCategoryOrder: normalizeProjectCategoryOrder(
+        projectCategories,
+        sanitizePersistedProjectCategoryOrder(parsed.projectCategoryOrder),
+      ),
       threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
         parsed.threadChangedFilesExpandedById,
       ),
@@ -111,6 +141,99 @@ function sanitizePersistedThreadChangedFilesExpanded(
   }
 
   return nextState;
+}
+
+function sanitizePersistedProjectCategories(
+  value: PersistedUiState["projectCategories"],
+): SidebarProjectCategory[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const categories: SidebarProjectCategory[] = [];
+  const seenIds = new Set<string>();
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const id = typeof entry.id === "string" ? entry.id.trim() : "";
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    const parentId =
+      typeof entry.parentId === "string" && entry.parentId.trim().length > 0
+        ? entry.parentId.trim()
+        : null;
+
+    if (!id || !name || seenIds.has(id)) {
+      continue;
+    }
+
+    seenIds.add(id);
+    categories.push({
+      id,
+      name,
+      parentId: parentId === id ? null : parentId,
+    });
+  }
+
+  return categories;
+}
+
+function sanitizePersistedProjectCategoryAssignments(
+  value: PersistedUiState["projectCategoryAssignmentsByPhysicalKey"],
+): Record<string, string> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const assignments: Record<string, string> = {};
+  for (const [physicalProjectKey, categoryId] of Object.entries(value)) {
+    const nextPhysicalProjectKey = physicalProjectKey.trim();
+    const nextCategoryId = typeof categoryId === "string" ? categoryId.trim() : "";
+    if (!nextPhysicalProjectKey || !nextCategoryId) {
+      continue;
+    }
+    assignments[nextPhysicalProjectKey] = nextCategoryId;
+  }
+
+  return assignments;
+}
+
+function sanitizePersistedProjectCategoryExpanded(
+  value: PersistedUiState["projectCategoryExpandedById"],
+): Record<string, boolean> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const expandedById: Record<string, boolean> = {};
+  for (const [categoryId, expanded] of Object.entries(value)) {
+    if (categoryId && expanded === false) {
+      expandedById[categoryId] = false;
+    }
+  }
+
+  return expandedById;
+}
+
+function sanitizePersistedProjectCategoryOrder(
+  value: PersistedUiState["projectCategoryOrder"],
+): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const categoryOrder: string[] = [];
+  for (const entry of value) {
+    const categoryId = typeof entry === "string" ? entry.trim() : "";
+    if (!categoryId || categoryOrder.includes(categoryId)) {
+      continue;
+    }
+    categoryOrder.push(categoryId);
+  }
+
+  return categoryOrder;
 }
 
 function hydratePersistedProjectState(parsed: PersistedUiState): void {
@@ -156,6 +279,14 @@ function persistState(state: UiState): void {
       JSON.stringify({
         expandedProjectCwds,
         projectOrderCwds,
+        projectCategories: state.projectCategories,
+        projectCategoryAssignmentsByPhysicalKey: state.projectCategoryAssignmentsByPhysicalKey,
+        projectCategoryExpandedById: Object.fromEntries(
+          Object.entries(state.projectCategoryExpandedById).filter(
+            ([, expanded]) => expanded === false,
+          ),
+        ),
+        projectCategoryOrder: state.projectCategoryOrder,
         threadChangedFilesExpandedById,
       } satisfies PersistedUiState),
     );
@@ -207,6 +338,44 @@ function nestedBooleanRecordsEqual(
     }
   }
   return true;
+}
+
+function normalizeProjectCategoryOrder(
+  categories: ReadonlyArray<SidebarProjectCategory>,
+  categoryOrder: ReadonlyArray<string>,
+): string[] {
+  const categoryIds = new Set(categories.map((category) => category.id));
+  const nextOrder = categoryOrder.filter((categoryId) => categoryIds.has(categoryId));
+
+  for (const category of categories) {
+    if (!nextOrder.includes(category.id)) {
+      nextOrder.push(category.id);
+    }
+  }
+
+  return nextOrder;
+}
+
+function normalizeProjectCategoryAssignments(
+  categories: ReadonlyArray<SidebarProjectCategory>,
+  assignments: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const categoryIds = new Set(categories.map((category) => category.id));
+  return Object.fromEntries(
+    Object.entries(assignments).filter(([, categoryId]) => categoryIds.has(categoryId)),
+  );
+}
+
+function normalizeProjectCategoryExpanded(
+  categories: ReadonlyArray<SidebarProjectCategory>,
+  expandedById: Readonly<Record<string, boolean>>,
+): Record<string, boolean> {
+  const categoryIds = new Set(categories.map((category) => category.id));
+  return Object.fromEntries(
+    Object.entries(expandedById).filter(
+      ([categoryId, expanded]) => categoryIds.has(categoryId) && expanded === false,
+    ),
+  );
 }
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
@@ -523,6 +692,231 @@ export function reorderProjects(
   };
 }
 
+export function addProjectCategory(
+  state: UiState,
+  input: { id: string; name: string; parentId: string | null },
+): UiState {
+  const id = input.id.trim();
+  const name = input.name.trim();
+  if (!id || !name || state.projectCategories.some((category) => category.id === id)) {
+    return state;
+  }
+
+  const projectCategories = [
+    ...state.projectCategories,
+    {
+      id,
+      name,
+      parentId:
+        input.parentId &&
+        canAssignSidebarProjectCategoryParent({
+          categories: state.projectCategories,
+          categoryId: id,
+          parentId: input.parentId,
+        })
+          ? input.parentId
+          : null,
+    },
+  ];
+
+  return {
+    ...state,
+    projectCategories,
+    projectCategoryOrder: normalizeProjectCategoryOrder(projectCategories, [
+      ...state.projectCategoryOrder,
+      id,
+    ]),
+  };
+}
+
+export function updateProjectCategory(
+  state: UiState,
+  input: { id: string; name: string; parentId: string | null },
+): UiState {
+  const existingCategory = state.projectCategories.find((category) => category.id === input.id);
+  const name = input.name.trim();
+  if (!existingCategory || !name) {
+    return state;
+  }
+
+  const parentId =
+    input.parentId &&
+    canAssignSidebarProjectCategoryParent({
+      categories: state.projectCategories,
+      categoryId: input.id,
+      parentId: input.parentId,
+    })
+      ? input.parentId
+      : null;
+
+  if (existingCategory.name === name && existingCategory.parentId === parentId) {
+    return state;
+  }
+
+  const projectCategories = state.projectCategories.map((category) =>
+    category.id === input.id
+      ? {
+          ...category,
+          name,
+          parentId,
+        }
+      : category,
+  );
+
+  return {
+    ...state,
+    projectCategories,
+    projectCategoryOrder: normalizeProjectCategoryOrder(
+      projectCategories,
+      state.projectCategoryOrder,
+    ),
+    projectCategoryAssignmentsByPhysicalKey: normalizeProjectCategoryAssignments(
+      projectCategories,
+      state.projectCategoryAssignmentsByPhysicalKey,
+    ),
+    projectCategoryExpandedById: normalizeProjectCategoryExpanded(
+      projectCategories,
+      state.projectCategoryExpandedById,
+    ),
+  };
+}
+
+export function deleteProjectCategory(state: UiState, categoryId: string): UiState {
+  const deletedCategory = state.projectCategories.find((category) => category.id === categoryId);
+  if (!deletedCategory) {
+    return state;
+  }
+
+  const projectCategories: SidebarProjectCategory[] = [];
+  for (const category of state.projectCategories) {
+    if (category.id === categoryId) {
+      continue;
+    }
+
+    if (category.parentId === categoryId) {
+      projectCategories.push({
+        id: category.id,
+        name: category.name,
+        parentId: deletedCategory.parentId,
+      });
+      continue;
+    }
+
+    projectCategories.push(category);
+  }
+  const projectCategoryAssignmentsByPhysicalKey = Object.fromEntries(
+    Object.entries(state.projectCategoryAssignmentsByPhysicalKey).flatMap(
+      ([physicalProjectKey, assignedCategoryId]) => {
+        if (assignedCategoryId !== categoryId) {
+          return [[physicalProjectKey, assignedCategoryId] as const];
+        }
+        return deletedCategory.parentId
+          ? [[physicalProjectKey, deletedCategory.parentId] as const]
+          : [];
+      },
+    ),
+  );
+  const { [categoryId]: _removedCategoryExpanded, ...projectCategoryExpandedById } =
+    state.projectCategoryExpandedById;
+
+  return {
+    ...state,
+    projectCategories,
+    projectCategoryOrder: normalizeProjectCategoryOrder(
+      projectCategories,
+      state.projectCategoryOrder,
+    ),
+    projectCategoryAssignmentsByPhysicalKey: normalizeProjectCategoryAssignments(
+      projectCategories,
+      projectCategoryAssignmentsByPhysicalKey,
+    ),
+    projectCategoryExpandedById: normalizeProjectCategoryExpanded(
+      projectCategories,
+      projectCategoryExpandedById,
+    ),
+  };
+}
+
+export function assignProjectsToCategory(
+  state: UiState,
+  physicalProjectKeys: readonly string[],
+  categoryId: string | null,
+): UiState {
+  if (physicalProjectKeys.length === 0) {
+    return state;
+  }
+
+  if (categoryId && !state.projectCategories.some((category) => category.id === categoryId)) {
+    return state;
+  }
+
+  const projectCategoryAssignmentsByPhysicalKey = {
+    ...state.projectCategoryAssignmentsByPhysicalKey,
+  };
+  let changed = false;
+
+  for (const physicalProjectKey of physicalProjectKeys) {
+    if (!physicalProjectKey) {
+      continue;
+    }
+
+    if (!categoryId) {
+      if (physicalProjectKey in projectCategoryAssignmentsByPhysicalKey) {
+        delete projectCategoryAssignmentsByPhysicalKey[physicalProjectKey];
+        changed = true;
+      }
+      continue;
+    }
+
+    if (projectCategoryAssignmentsByPhysicalKey[physicalProjectKey] === categoryId) {
+      continue;
+    }
+
+    projectCategoryAssignmentsByPhysicalKey[physicalProjectKey] = categoryId;
+    changed = true;
+  }
+
+  if (!changed) {
+    return state;
+  }
+
+  return {
+    ...state,
+    projectCategoryAssignmentsByPhysicalKey,
+  };
+}
+
+export function setProjectCategoryExpanded(
+  state: UiState,
+  categoryId: string,
+  expanded: boolean,
+): UiState {
+  const currentExpanded = state.projectCategoryExpandedById[categoryId] ?? true;
+  if (currentExpanded === expanded) {
+    return state;
+  }
+
+  if (expanded) {
+    if (!(categoryId in state.projectCategoryExpandedById)) {
+      return state;
+    }
+    const nextExpandedById = { ...state.projectCategoryExpandedById };
+    delete nextExpandedById[categoryId];
+    return {
+      ...state,
+      projectCategoryExpandedById: nextExpandedById,
+    };
+  }
+
+  return {
+    ...state,
+    projectCategoryExpandedById: {
+      ...state.projectCategoryExpandedById,
+      [categoryId]: false,
+    },
+  };
+}
+
 interface UiStateStore extends UiState {
   syncProjects: (projects: readonly SyncProjectInput[]) => void;
   syncThreads: (threads: readonly SyncThreadInput[]) => void;
@@ -532,6 +926,14 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   toggleProject: (projectId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
+  addProjectCategory: (input: { name: string; parentId: string | null }) => string | null;
+  updateProjectCategory: (input: { id: string; name: string; parentId: string | null }) => void;
+  deleteProjectCategory: (categoryId: string) => void;
+  assignProjectsToCategory: (
+    physicalProjectKeys: readonly string[],
+    categoryId: string | null,
+  ) => void;
+  setProjectCategoryExpanded: (categoryId: string, expanded: boolean) => void;
   reorderProjects: (
     draggedProjectIds: readonly string[],
     targetProjectIds: readonly string[],
@@ -552,6 +954,24 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),
+  addProjectCategory: ({ name, parentId }) => {
+    const id =
+      globalThis.crypto?.randomUUID?.() ??
+      `category-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    let created = false;
+    set((state) => {
+      const nextState = addProjectCategory(state, { id, name, parentId });
+      created = nextState !== state;
+      return nextState;
+    });
+    return created ? id : null;
+  },
+  updateProjectCategory: (input) => set((state) => updateProjectCategory(state, input)),
+  deleteProjectCategory: (categoryId) => set((state) => deleteProjectCategory(state, categoryId)),
+  assignProjectsToCategory: (physicalProjectKeys, categoryId) =>
+    set((state) => assignProjectsToCategory(state, physicalProjectKeys, categoryId)),
+  setProjectCategoryExpanded: (categoryId, expanded) =>
+    set((state) => setProjectCategoryExpanded(state, categoryId, expanded)),
   reorderProjects: (draggedProjectIds, targetProjectIds) =>
     set((state) => reorderProjects(state, draggedProjectIds, targetProjectIds)),
 }));


### PR DESCRIPTION
Part of #4

## Summary
- add nested sidebar project categories with persisted order, parentage, and expansion state
- let projects be assigned to categories from the project context menu and by dragging them onto category rows in manual sort mode
- keep the existing sidebar design language while rendering nested category groups around logical projects

## Checklist
- [x] Add nested project categories to the sidebar
- [x] Support moving projects into categories via drag and drop
- [x] Persist category metadata and assignments in UI state
- [x] Add reducer and tree-building tests for the new category model
- [ ] Manual local verification

## Checks
- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `cd apps/web && bun run test -- uiStateStore sidebarProjectCategories`
