### PR TITLE
Add workspace agent diff preview

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,5 +1,4 @@
-import { parsePatchFiles } from "@pierre/diffs";
-import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
+import { FileDiff, Virtualizer } from "@pierre/diffs/react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { scopeThreadRef } from "@t3tools/client-runtime";
@@ -27,9 +26,14 @@ import { readLocalApi } from "../localApi";
 import { resolvePathLinkTarget } from "../terminal-links";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
-import { buildPatchCacheKey } from "../lib/diffRendering";
 import { resolveDiffThemeName } from "../lib/diffRendering";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
+import {
+  buildFileDiffRenderKey,
+  DIFF_VIEWER_UNSAFE_CSS,
+  getRenderablePatch,
+  resolveFileDiffPath,
+} from "../lib/patchDiff";
 import { selectProjectByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
@@ -40,125 +44,6 @@ import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
 type DiffThemeType = "light" | "dark";
-
-const DIFF_PANEL_UNSAFE_CSS = `
-[data-diffs-header],
-[data-diff],
-[data-file],
-[data-error-wrapper],
-[data-virtualizer-buffer] {
-  --diffs-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-light-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-dark-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-token-light-bg: transparent;
-  --diffs-token-dark-bg: transparent;
-
-  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
-  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
-  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
-  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
-
-  --diffs-bg-addition-override: color-mix(in srgb, var(--background) 92%, var(--success));
-  --diffs-bg-addition-number-override: color-mix(in srgb, var(--background) 88%, var(--success));
-  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
-  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
-
-  --diffs-bg-deletion-override: color-mix(in srgb, var(--background) 92%, var(--destructive));
-  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--background) 88%, var(--destructive));
-  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
-  --diffs-bg-deletion-emphasis-override: color-mix(
-    in srgb,
-    var(--background) 80%,
-    var(--destructive)
-  );
-
-  background-color: var(--diffs-bg) !important;
-}
-
-[data-file-info] {
-  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
-  border-block-color: var(--border) !important;
-  color: var(--foreground) !important;
-}
-
-[data-diffs-header] {
-  position: sticky !important;
-  top: 0;
-  z-index: 4;
-  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
-  border-bottom: 1px solid var(--border) !important;
-}
-
-[data-title] {
-  cursor: pointer;
-  transition:
-    color 120ms ease,
-    text-decoration-color 120ms ease;
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  text-underline-offset: 2px;
-}
-
-[data-title]:hover {
-  color: color-mix(in srgb, var(--foreground) 84%, var(--primary)) !important;
-  text-decoration-color: currentColor;
-}
-`;
-
-type RenderablePatch =
-  | {
-      kind: "files";
-      files: FileDiffMetadata[];
-    }
-  | {
-      kind: "raw";
-      text: string;
-      reason: string;
-    };
-
-function getRenderablePatch(
-  patch: string | undefined,
-  cacheScope = "diff-panel",
-): RenderablePatch | null {
-  if (!patch) return null;
-  const normalizedPatch = patch.trim();
-  if (normalizedPatch.length === 0) return null;
-
-  try {
-    const parsedPatches = parsePatchFiles(
-      normalizedPatch,
-      buildPatchCacheKey(normalizedPatch, cacheScope),
-    );
-    const files = parsedPatches.flatMap((parsedPatch) => parsedPatch.files);
-    if (files.length > 0) {
-      return { kind: "files", files };
-    }
-
-    return {
-      kind: "raw",
-      text: normalizedPatch,
-      reason: "Unsupported diff format. Showing raw patch.",
-    };
-  } catch {
-    return {
-      kind: "raw",
-      text: normalizedPatch,
-      reason: "Failed to parse patch. Showing raw patch.",
-    };
-  }
-}
-
-function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
-  const raw = fileDiff.name ?? fileDiff.prevName ?? "";
-  if (raw.startsWith("a/") || raw.startsWith("b/")) {
-    return raw.slice(2);
-  }
-  return raw;
-}
-
-function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
-  return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
-}
 
 interface DiffPanelProps {
   mode?: DiffPanelMode;
@@ -628,7 +513,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                           overflow: diffWordWrap ? "wrap" : "scroll",
                           theme: resolveDiffThemeName(resolvedTheme),
                           themeType: resolvedTheme as DiffThemeType,
-                          unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
+                          unsafeCSS: DIFF_VIEWER_UNSAFE_CSS,
                         }}
                       />
                     </div>

--- a/apps/web/src/components/WorkspaceAgentDiffPreview.tsx
+++ b/apps/web/src/components/WorkspaceAgentDiffPreview.tsx
@@ -1,0 +1,216 @@
+import { FileDiff } from "@pierre/diffs/react";
+import { useQuery } from "@tanstack/react-query";
+import { type EnvironmentId, type ThreadId, type TurnId } from "@t3tools/contracts";
+import { ExternalLinkIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { useSettings } from "~/hooks/useSettings";
+import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
+import { cn } from "~/lib/utils";
+import { formatShortTimestamp } from "~/timestampFormat";
+
+import { resolveDiffThemeName } from "../lib/diffRendering";
+import { DIFF_VIEWER_UNSAFE_CSS, getRenderablePatch, resolveFileDiffPath } from "../lib/patchDiff";
+import { type WorkspaceAgentFileDiff } from "../lib/workspaceAgentDiffs";
+import { Button } from "./ui/button";
+import { DiffStatLabel, hasNonZeroStat } from "./chat/DiffStatLabel";
+
+type DiffThemeType = "light" | "dark";
+
+interface WorkspaceAgentDiffPreviewProps {
+  environmentId: EnvironmentId;
+  threadId: ThreadId;
+  filePath: string;
+  fileHistory: ReadonlyArray<WorkspaceAgentFileDiff>;
+  resolvedTheme: "light" | "dark";
+  onOpenFullDiff: (turnId: TurnId, filePath: string) => void;
+}
+
+export function WorkspaceAgentDiffPreview(props: WorkspaceAgentDiffPreviewProps) {
+  const { environmentId, fileHistory, filePath, onOpenFullDiff, resolvedTheme, threadId } = props;
+  const settings = useSettings();
+  const [selectedTurnId, setSelectedTurnId] = useState<TurnId | null>(
+    () => fileHistory[0]?.turnId ?? null,
+  );
+
+  useEffect(() => {
+    if (fileHistory.length === 0) {
+      setSelectedTurnId(null);
+      return;
+    }
+
+    const selectedStillExists = fileHistory.some((entry) => entry.turnId === selectedTurnId);
+    if (!selectedStillExists) {
+      setSelectedTurnId(fileHistory[0]?.turnId ?? null);
+    }
+  }, [fileHistory, selectedTurnId]);
+
+  const selectedHistoryEntry =
+    (selectedTurnId ? fileHistory.find((entry) => entry.turnId === selectedTurnId) : undefined) ??
+    fileHistory[0] ??
+    null;
+  const checkpointRange = useMemo(() => {
+    if (typeof selectedHistoryEntry?.checkpointTurnCount !== "number") {
+      return null;
+    }
+    return {
+      fromTurnCount: Math.max(0, selectedHistoryEntry.checkpointTurnCount - 1),
+      toTurnCount: selectedHistoryEntry.checkpointTurnCount,
+    };
+  }, [selectedHistoryEntry?.checkpointTurnCount]);
+
+  const activeDiffQuery = useQuery(
+    checkpointDiffQueryOptions({
+      environmentId,
+      threadId,
+      fromTurnCount: checkpointRange?.fromTurnCount ?? null,
+      toTurnCount: checkpointRange?.toTurnCount ?? null,
+      cacheScope: selectedHistoryEntry
+        ? `workspace-file:${filePath}:${selectedHistoryEntry.turnId}`
+        : null,
+      enabled: selectedHistoryEntry !== null && checkpointRange !== null,
+    }),
+  );
+  const renderablePatch = useMemo(
+    () =>
+      getRenderablePatch(
+        activeDiffQuery.data?.diff,
+        selectedHistoryEntry
+          ? `workspace-file:${selectedHistoryEntry.turnId}:${resolvedTheme}`
+          : "workspace-file",
+      ),
+    [activeDiffQuery.data?.diff, resolvedTheme, selectedHistoryEntry],
+  );
+  const renderableFile = useMemo(() => {
+    if (!renderablePatch || renderablePatch.kind !== "files") {
+      return null;
+    }
+    return (
+      renderablePatch.files.find((fileDiff) => resolveFileDiffPath(fileDiff) === filePath) ?? null
+    );
+  }, [filePath, renderablePatch]);
+  const diffError =
+    activeDiffQuery.error instanceof Error
+      ? activeDiffQuery.error.message
+      : activeDiffQuery.error
+        ? "Failed to load agent diff preview."
+        : null;
+
+  if (!selectedHistoryEntry) {
+    return null;
+  }
+
+  return (
+    <div className="flex shrink-0 flex-col border-t border-border/60 bg-card/20">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 px-3 py-2">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground/70">
+            Agent diff
+          </div>
+          <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground/80">
+            <span className="truncate">
+              {fileHistory.length} turn{fileHistory.length === 1 ? "" : "s"}
+            </span>
+            {hasNonZeroStat(selectedHistoryEntry.stat) ? (
+              <span className="font-mono tabular-nums">
+                <DiffStatLabel
+                  additions={selectedHistoryEntry.stat.additions}
+                  deletions={selectedHistoryEntry.stat.deletions}
+                />
+              </span>
+            ) : (
+              <span>Changed</span>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="xs"
+          variant="outline"
+          onClick={() => onOpenFullDiff(selectedHistoryEntry.turnId, filePath)}
+        >
+          <ExternalLinkIcon className="size-3" />
+          Full diff
+        </Button>
+      </div>
+
+      <div className="flex gap-1 overflow-x-auto border-b border-border/50 px-3 py-2">
+        {fileHistory.map((entry) => {
+          const selected = entry.turnId === selectedHistoryEntry.turnId;
+          return (
+            <button
+              key={entry.turnId}
+              type="button"
+              className={cn(
+                "shrink-0 rounded-md border px-2 py-1 text-left transition-colors",
+                selected
+                  ? "border-border bg-accent text-accent-foreground"
+                  : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/85",
+              )}
+              onClick={() => setSelectedTurnId(entry.turnId)}
+            >
+              <div className="text-[10px] font-medium leading-tight">
+                Turn {entry.checkpointTurnCount ?? "?"}
+              </div>
+              <div className="mt-0.5 flex items-center gap-1 text-[9px] leading-tight opacity-75">
+                <span>{formatShortTimestamp(entry.completedAt, settings.timestampFormat)}</span>
+                {hasNonZeroStat(entry.stat) ? (
+                  <span className="font-mono tabular-nums">
+                    <DiffStatLabel
+                      additions={entry.stat.additions}
+                      deletions={entry.stat.deletions}
+                    />
+                  </span>
+                ) : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="max-h-[18rem] min-h-[12rem] overflow-auto bg-background/70 p-2">
+        {diffError && !renderablePatch ? (
+          <div className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive/80">
+            {diffError}
+          </div>
+        ) : activeDiffQuery.isLoading && !renderablePatch ? (
+          <div className="flex h-full min-h-[10rem] items-center justify-center text-xs text-muted-foreground/70">
+            Loading agent diff preview...
+          </div>
+        ) : renderableFile ? (
+          <div className="overflow-hidden rounded-md border border-border/60 bg-card">
+            <FileDiff
+              fileDiff={renderableFile}
+              options={{
+                diffStyle: "unified",
+                lineDiffType: "none",
+                overflow: settings.diffWordWrap ? "wrap" : "scroll",
+                theme: resolveDiffThemeName(resolvedTheme),
+                themeType: resolvedTheme as DiffThemeType,
+                unsafeCSS: DIFF_VIEWER_UNSAFE_CSS,
+              }}
+            />
+          </div>
+        ) : renderablePatch?.kind === "raw" ? (
+          <div className="space-y-2">
+            <p className="text-[11px] text-muted-foreground/75">{renderablePatch.reason}</p>
+            <pre
+              className={cn(
+                "rounded-md border border-border/70 bg-background/70 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground/90",
+                settings.diffWordWrap
+                  ? "overflow-auto whitespace-pre-wrap wrap-break-word"
+                  : "overflow-auto",
+              )}
+            >
+              {renderablePatch.text}
+            </pre>
+          </div>
+        ) : (
+          <div className="flex h-full min-h-[10rem] items-center justify-center px-4 text-center text-xs text-muted-foreground/70">
+            No file-specific patch is available for this turn.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspacePanel.tsx
+++ b/apps/web/src/components/WorkspacePanel.tsx
@@ -1,22 +1,24 @@
 import Editor from "@monaco-editor/react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import type {
   ProjectCreateEntryInput,
   ProjectDirectoryEntry,
   ProjectReadFileResult,
+  TurnId,
 } from "@t3tools/contracts";
+import { scopeThreadRef } from "@t3tools/client-runtime";
 import { createThreadSelectorByRef } from "~/storeSelectors";
 import {
+  ChevronRightIcon,
   FilePlus2Icon,
+  FileWarningIcon,
   FolderClosedIcon,
   FolderPlusIcon,
   HardDriveUploadIcon,
   LoaderCircleIcon,
   RefreshCcwIcon,
   SaveIcon,
-  ChevronRightIcon,
-  FileWarningIcon,
 } from "lucide-react";
 import {
   type ChangeEvent,
@@ -30,7 +32,10 @@ import {
 } from "react";
 
 import { ensureEnvironmentApi } from "~/environmentApi";
+import { stripDiffSearchParams } from "~/diffRouteSearch";
 import { useTheme } from "~/hooks/useTheme";
+import { useTurnDiffSummaries } from "~/hooks/useTurnDiffSummaries";
+import { buildWorkspaceAgentFileDiffHistory } from "~/lib/workspaceAgentDiffs";
 import {
   workspaceListDirectoryQueryOptions,
   workspaceQueryKeys,
@@ -38,10 +43,12 @@ import {
 } from "~/lib/workspaceReactQuery";
 import { cn } from "~/lib/utils";
 import { selectProjectByRef, useStore } from "~/store";
-import { resolveThreadRouteRef } from "~/threadRoutes";
+import { buildThreadRouteParams, resolveThreadRouteRef } from "~/threadRoutes";
 import { basenameOfPath } from "~/vscode-icons";
 
+import { DiffStatLabel, hasNonZeroStat } from "./chat/DiffStatLabel";
 import { VscodeEntryIcon } from "./chat/VscodeEntryIcon";
+import { WorkspaceAgentDiffPreview } from "./WorkspaceAgentDiffPreview";
 import {
   WorkspacePanelLoadingState,
   WorkspacePanelShell,
@@ -112,6 +119,8 @@ const WorkspaceExplorerRow = memo(function WorkspaceExplorerRow(props: {
   selected: boolean;
   dropTarget: boolean;
   resolvedTheme: "light" | "dark";
+  agentChanged: boolean;
+  agentDiffStat?: { additions: number; deletions: number } | null;
   onToggleDirectory: (directoryPath: string) => void;
   onOpenFile: (relativePath: string) => void;
   onSelectEntry: (entry: Pick<ProjectDirectoryEntry, "kind" | "path">) => void;
@@ -174,6 +183,7 @@ const WorkspaceExplorerRow = memo(function WorkspaceExplorerRow(props: {
         props.selected
           ? "bg-accent text-accent-foreground"
           : "text-muted-foreground/80 hover:bg-accent/70 hover:text-foreground",
+        props.agentChanged && "text-foreground/90",
       )}
       style={{ paddingLeft: `${paddingLeft + 18}px` }}
       onClick={() => {
@@ -188,6 +198,18 @@ const WorkspaceExplorerRow = memo(function WorkspaceExplorerRow(props: {
         className="size-3.5"
       />
       <span className="truncate text-xs">{entry.name}</span>
+      {props.agentChanged ? (
+        <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+          {props.agentDiffStat && hasNonZeroStat(props.agentDiffStat) ? (
+            <DiffStatLabel
+              additions={props.agentDiffStat.additions}
+              deletions={props.agentDiffStat.deletions}
+            />
+          ) : (
+            <span className="text-primary/80">changed</span>
+          )}
+        </span>
+      ) : null}
     </button>
   );
 });
@@ -197,6 +219,7 @@ interface WorkspacePanelProps {
 }
 
 export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps) {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { resolvedTheme } = useTheme();
   const routeThreadRef = useParams({
@@ -217,6 +240,13 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
   const activeWorkspaceRoot = activeThread?.worktreePath ?? activeProject?.cwd ?? null;
   const workspaceLabel = activeWorkspaceRoot ? basenameOfPath(activeWorkspaceRoot) : "Workspace";
   const workspaceScopeLabel = activeThread?.worktreePath ? "Thread workspace" : "Project workspace";
+  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
+    useTurnDiffSummaries(activeThread);
+  const workspaceAgentDiffHistoryByPath = useMemo(
+    () =>
+      buildWorkspaceAgentFileDiffHistory(turnDiffSummaries, inferredCheckpointTurnCountByTurnId),
+    [inferredCheckpointTurnCountByTurnId, turnDiffSummaries],
+  );
   const workspaceRootRef = useRef(activeWorkspaceRoot);
   workspaceRootRef.current = activeWorkspaceRoot;
 
@@ -451,6 +481,9 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
     return dirtyPaths;
   }, [draftByPath, fileStateByPath, openTabs]);
   const activeFileDirty = activeFilePath ? dirtyFilePathSet.has(activeFilePath) : false;
+  const activeFileDiffHistory = activeFilePath
+    ? (workspaceAgentDiffHistoryByPath.get(activeFilePath) ?? [])
+    : [];
 
   const actionDirectoryPath =
     selectedEntry.kind === "directory"
@@ -460,6 +493,23 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
         : activeFilePath
           ? parentDirectoryOf(activeFilePath)
           : null;
+  const openFileDiff = useCallback(
+    (turnId: TurnId, filePath: string) => {
+      if (!activeThread) {
+        return;
+      }
+
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+        search: (previous) => {
+          const rest = stripDiffSearchParams(previous);
+          return { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath };
+        },
+      });
+    },
+    [activeThread, navigate],
+  );
 
   const saveActiveFile = useCallback(async () => {
     if (!activeThread || !activeWorkspaceRoot || !activeFilePath || !activeFileState) {
@@ -715,6 +765,7 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
       entries.map((entry) => {
         const isDirectoryExpanded = Boolean(expandedDirectoriesByPath[directoryKey(entry.path)]);
         const childEntries = directoryEntriesByPath[directoryKey(entry.path)] ?? [];
+        const latestAgentDiff = workspaceAgentDiffHistoryByPath.get(entry.path)?.[0] ?? null;
         return (
           <WorkspaceExplorerRow
             key={entry.path}
@@ -725,6 +776,8 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
             selected={selectedEntry.path === entry.path}
             dropTarget={dropTargetDirectoryPath === entry.path}
             resolvedTheme={resolvedTheme}
+            agentChanged={latestAgentDiff !== null}
+            agentDiffStat={latestAgentDiff?.stat ?? null}
             onToggleDirectory={toggleDirectory}
             onOpenFile={openFile}
             onSelectEntry={setSelectedEntry}
@@ -750,6 +803,7 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
       resolvedTheme,
       selectedEntry.path,
       toggleDirectory,
+      workspaceAgentDiffHistoryByPath,
     ],
   );
 
@@ -943,6 +997,7 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
                 openTabs.map((tabPath) => {
                   const dirty = dirtyFilePathSet.has(tabPath);
                   const active = tabPath === activeFilePath;
+                  const latestAgentDiff = workspaceAgentDiffHistoryByPath.get(tabPath)?.[0] ?? null;
                   return (
                     <div
                       key={tabPath}
@@ -970,6 +1025,18 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
                             unsaved
                           </span>
                         ) : null}
+                        {!dirty && latestAgentDiff ? (
+                          <span className="font-mono text-[9px] tabular-nums text-muted-foreground/80">
+                            {hasNonZeroStat(latestAgentDiff.stat) ? (
+                              <DiffStatLabel
+                                additions={latestAgentDiff.stat.additions}
+                                deletions={latestAgentDiff.stat.deletions}
+                              />
+                            ) : (
+                              "agent"
+                            )}
+                          </span>
+                        ) : null}
                       </button>
                       <button
                         type="button"
@@ -986,67 +1053,80 @@ export default function WorkspacePanel({ mode = "inline" }: WorkspacePanelProps)
             </div>
           </div>
 
-          <div className="min-h-0 flex-1">
-            {!activeFilePath ? (
-              <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
-                <div className="rounded-full border border-border/70 bg-card/70 p-3">
-                  <FilePlus2Icon className="size-5 text-muted-foreground/70" />
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1">
+              {!activeFilePath ? (
+                <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+                  <div className="rounded-full border border-border/70 bg-card/70 p-3">
+                    <FilePlus2Icon className="size-5 text-muted-foreground/70" />
+                  </div>
+                  <div className="text-sm font-medium text-foreground">
+                    Select a file to start editing
+                  </div>
+                  <div className="max-w-md text-xs text-muted-foreground/70">
+                    Create a file, upload one into the explorer, or open an existing file from the
+                    workspace tree.
+                  </div>
                 </div>
-                <div className="text-sm font-medium text-foreground">
-                  Select a file to start editing
+              ) : loadingFilePath === activeFilePath && !activeFileState ? (
+                <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground/70">
+                  <LoaderCircleIcon className="size-4 animate-spin" />
+                  Loading file…
                 </div>
-                <div className="max-w-md text-xs text-muted-foreground/70">
-                  Create a file, upload one into the explorer, or open an existing file from the
-                  workspace tree.
+              ) : activeFileState?.isBinary ? (
+                <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+                  <FileWarningIcon className="size-5 text-muted-foreground/70" />
+                  <div className="text-sm font-medium text-foreground">
+                    Binary files aren&apos;t editable here yet
+                  </div>
+                  <div className="text-xs text-muted-foreground/70">{activeFilePath}</div>
                 </div>
-              </div>
-            ) : loadingFilePath === activeFilePath && !activeFileState ? (
-              <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground/70">
-                <LoaderCircleIcon className="size-4 animate-spin" />
-                Loading file…
-              </div>
-            ) : activeFileState?.isBinary ? (
-              <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
-                <FileWarningIcon className="size-5 text-muted-foreground/70" />
-                <div className="text-sm font-medium text-foreground">
-                  Binary files aren&apos;t editable here yet
+              ) : activeFileState?.tooLarge ? (
+                <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+                  <FileWarningIcon className="size-5 text-muted-foreground/70" />
+                  <div className="text-sm font-medium text-foreground">
+                    This file is too large to open in the editor
+                  </div>
+                  <div className="text-xs text-muted-foreground/70">{activeFilePath}</div>
                 </div>
-                <div className="text-xs text-muted-foreground/70">{activeFilePath}</div>
-              </div>
-            ) : activeFileState?.tooLarge ? (
-              <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
-                <FileWarningIcon className="size-5 text-muted-foreground/70" />
-                <div className="text-sm font-medium text-foreground">
-                  This file is too large to open in the editor
+              ) : activeFileState ? (
+                <Editor
+                  height="100%"
+                  path={activeFilePath}
+                  theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
+                  value={activeFileDraft}
+                  onChange={(nextValue) => {
+                    setDraftByPath((current) => ({
+                      ...current,
+                      [activeFilePath]: nextValue ?? "",
+                    }));
+                  }}
+                  options={{
+                    automaticLayout: true,
+                    fontSize: 13,
+                    minimap: { enabled: false },
+                    scrollBeyondLastLine: false,
+                    smoothScrolling: true,
+                    wordWrap: "on",
+                  }}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
+                  Select a file to start editing.
                 </div>
-                <div className="text-xs text-muted-foreground/70">{activeFilePath}</div>
-              </div>
-            ) : activeFileState ? (
-              <Editor
-                height="100%"
-                path={activeFilePath}
-                theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
-                value={activeFileDraft}
-                onChange={(nextValue) => {
-                  setDraftByPath((current) => ({
-                    ...current,
-                    [activeFilePath]: nextValue ?? "",
-                  }));
-                }}
-                options={{
-                  automaticLayout: true,
-                  fontSize: 13,
-                  minimap: { enabled: false },
-                  scrollBeyondLastLine: false,
-                  smoothScrolling: true,
-                  wordWrap: "on",
-                }}
+              )}
+            </div>
+
+            {activeFilePath && activeFileDiffHistory.length > 0 ? (
+              <WorkspaceAgentDiffPreview
+                environmentId={activeThread.environmentId}
+                threadId={activeThread.id}
+                filePath={activeFilePath}
+                fileHistory={activeFileDiffHistory}
+                resolvedTheme={resolvedTheme}
+                onOpenFullDiff={openFileDiff}
               />
-            ) : (
-              <div className="flex h-full items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
-                Select a file to start editing.
-              </div>
-            )}
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/patchDiff.ts
+++ b/apps/web/src/lib/patchDiff.ts
@@ -1,0 +1,125 @@
+import { parsePatchFiles } from "@pierre/diffs";
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+
+import { buildPatchCacheKey } from "./diffRendering";
+
+export const DIFF_VIEWER_UNSAFE_CSS = `
+[data-diffs-header],
+[data-diff],
+[data-file],
+[data-error-wrapper],
+[data-virtualizer-buffer] {
+  --diffs-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
+  --diffs-light-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
+  --diffs-dark-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
+  --diffs-token-light-bg: transparent;
+  --diffs-token-dark-bg: transparent;
+
+  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
+  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
+  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
+  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
+
+  --diffs-bg-addition-override: color-mix(in srgb, var(--background) 92%, var(--success));
+  --diffs-bg-addition-number-override: color-mix(in srgb, var(--background) 88%, var(--success));
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
+  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
+
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--background) 92%, var(--destructive));
+  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--background) 88%, var(--destructive));
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
+  --diffs-bg-deletion-emphasis-override: color-mix(
+    in srgb,
+    var(--background) 80%,
+    var(--destructive)
+  );
+
+  background-color: var(--diffs-bg) !important;
+}
+
+[data-file-info] {
+  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
+  border-block-color: var(--border) !important;
+  color: var(--foreground) !important;
+}
+
+[data-diffs-header] {
+  position: sticky !important;
+  top: 0;
+  z-index: 4;
+  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+[data-title] {
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 2px;
+}
+
+[data-title]:hover {
+  color: color-mix(in srgb, var(--foreground) 84%, var(--primary)) !important;
+  text-decoration-color: currentColor;
+}
+`;
+
+export type RenderablePatch =
+  | {
+      kind: "files";
+      files: FileDiffMetadata[];
+    }
+  | {
+      kind: "raw";
+      text: string;
+      reason: string;
+    };
+
+export function getRenderablePatch(
+  patch: string | undefined,
+  cacheScope = "diff-panel",
+): RenderablePatch | null {
+  if (!patch) return null;
+  const normalizedPatch = patch.trim();
+  if (normalizedPatch.length === 0) return null;
+
+  try {
+    const parsedPatches = parsePatchFiles(
+      normalizedPatch,
+      buildPatchCacheKey(normalizedPatch, cacheScope),
+    );
+    const files = parsedPatches.flatMap((parsedPatch) => parsedPatch.files);
+    if (files.length > 0) {
+      return { kind: "files", files };
+    }
+
+    return {
+      kind: "raw",
+      text: normalizedPatch,
+      reason: "Unsupported diff format. Showing raw patch.",
+    };
+  } catch {
+    return {
+      kind: "raw",
+      text: normalizedPatch,
+      reason: "Failed to parse patch. Showing raw patch.",
+    };
+  }
+}
+
+export function resolveFileDiffPath(fileDiff: Pick<FileDiffMetadata, "name" | "prevName">): string {
+  const raw = fileDiff.name ?? fileDiff.prevName ?? "";
+  if (raw.startsWith("a/") || raw.startsWith("b/")) {
+    return raw.slice(2);
+  }
+  return raw;
+}
+
+export function buildFileDiffRenderKey(
+  fileDiff: Pick<FileDiffMetadata, "cacheKey" | "name" | "prevName">,
+): string {
+  return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
+}

--- a/apps/web/src/lib/workspaceAgentDiffs.test.ts
+++ b/apps/web/src/lib/workspaceAgentDiffs.test.ts
@@ -1,0 +1,84 @@
+import { TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import type { TurnDiffSummary } from "../types";
+import { buildWorkspaceAgentFileDiffHistory } from "./workspaceAgentDiffs";
+
+describe("buildWorkspaceAgentFileDiffHistory", () => {
+  it("groups file changes by path and sorts the latest turn first", () => {
+    const firstTurnId = TurnId.make("turn-1");
+    const secondTurnId = TurnId.make("turn-2");
+    const thirdTurnId = TurnId.make("turn-3");
+    const histories = buildWorkspaceAgentFileDiffHistory(
+      [
+        {
+          turnId: firstTurnId,
+          completedAt: "2026-04-16T09:00:00.000Z",
+          files: [{ path: "src/app.tsx", additions: 2, deletions: 1 }],
+        },
+        {
+          turnId: secondTurnId,
+          completedAt: "2026-04-16T10:00:00.000Z",
+          files: [{ path: "src/app.tsx", additions: 5, deletions: 0 }],
+        },
+        {
+          turnId: thirdTurnId,
+          completedAt: "2026-04-16T11:00:00.000Z",
+          checkpointTurnCount: 7,
+          files: [{ path: "src/app.tsx", additions: 1, deletions: 4 }],
+        },
+      ] satisfies TurnDiffSummary[],
+      {
+        [firstTurnId]: 2,
+        [secondTurnId]: 3,
+      },
+    );
+
+    expect(histories.get("src/app.tsx")).toEqual([
+      {
+        path: "src/app.tsx",
+        turnId: thirdTurnId,
+        completedAt: "2026-04-16T11:00:00.000Z",
+        checkpointTurnCount: 7,
+        stat: { additions: 1, deletions: 4 },
+      },
+      {
+        path: "src/app.tsx",
+        turnId: secondTurnId,
+        completedAt: "2026-04-16T10:00:00.000Z",
+        checkpointTurnCount: 3,
+        stat: { additions: 5, deletions: 0 },
+      },
+      {
+        path: "src/app.tsx",
+        turnId: firstTurnId,
+        completedAt: "2026-04-16T09:00:00.000Z",
+        checkpointTurnCount: 2,
+        stat: { additions: 2, deletions: 1 },
+      },
+    ]);
+  });
+
+  it("normalizes path separators and fills in missing diff stats", () => {
+    const turnId = TurnId.make("turn-1");
+    const histories = buildWorkspaceAgentFileDiffHistory(
+      [
+        {
+          turnId,
+          completedAt: "2026-04-16T09:00:00.000Z",
+          files: [{ path: "\\src\\index.ts" }],
+        },
+      ] satisfies TurnDiffSummary[],
+      {},
+    );
+
+    expect(histories.get("src/index.ts")).toEqual([
+      {
+        path: "src/index.ts",
+        turnId,
+        completedAt: "2026-04-16T09:00:00.000Z",
+        stat: { additions: 0, deletions: 0 },
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/workspaceAgentDiffs.ts
+++ b/apps/web/src/lib/workspaceAgentDiffs.ts
@@ -1,0 +1,71 @@
+import type { TurnId } from "@t3tools/contracts";
+
+import type { TurnDiffSummary } from "../types";
+
+export interface WorkspaceAgentDiffStat {
+  additions: number;
+  deletions: number;
+}
+
+export interface WorkspaceAgentFileDiff {
+  path: string;
+  turnId: TurnId;
+  completedAt: string;
+  checkpointTurnCount?: number;
+  stat: WorkspaceAgentDiffStat;
+}
+
+function normalizeWorkspaceDiffPath(pathValue: string): string {
+  return pathValue.replaceAll("\\", "/").replace(/^\/+|\/+$/g, "");
+}
+
+function compareWorkspaceAgentDiffs(
+  left: WorkspaceAgentFileDiff,
+  right: WorkspaceAgentFileDiff,
+): number {
+  const leftTurnCount = left.checkpointTurnCount ?? -1;
+  const rightTurnCount = right.checkpointTurnCount ?? -1;
+  if (leftTurnCount !== rightTurnCount) {
+    return rightTurnCount - leftTurnCount;
+  }
+  return right.completedAt.localeCompare(left.completedAt);
+}
+
+export function buildWorkspaceAgentFileDiffHistory(
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>,
+  inferredCheckpointTurnCountByTurnId: Partial<Record<TurnId, number>>,
+): ReadonlyMap<string, ReadonlyArray<WorkspaceAgentFileDiff>> {
+  const fileHistoryByPath = new Map<string, WorkspaceAgentFileDiff[]>();
+
+  for (const summary of turnDiffSummaries) {
+    const checkpointTurnCount =
+      summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId];
+
+    for (const file of summary.files) {
+      const path = normalizeWorkspaceDiffPath(file.path);
+      if (path.length === 0) {
+        continue;
+      }
+
+      const history = fileHistoryByPath.get(path) ?? [];
+      history.push({
+        path,
+        turnId: summary.turnId,
+        completedAt: summary.completedAt,
+        ...(checkpointTurnCount !== undefined ? { checkpointTurnCount } : {}),
+        stat: {
+          additions: file.additions ?? 0,
+          deletions: file.deletions ?? 0,
+        },
+      });
+      fileHistoryByPath.set(path, history);
+    }
+  }
+
+  return new Map(
+    Array.from(fileHistoryByPath.entries(), ([path, history]) => [
+      path,
+      history.toSorted(compareWorkspaceAgentDiffs),
+    ]),
+  );
+}


### PR DESCRIPTION
Part of #4

Closes #3

## Summary
- surface live coding-agent change stats on changed files in the workspace tree and open tabs
- add an inline workspace diff preview for the selected file using the existing checkpoint diff pipeline
- reuse shared patch parsing/rendering helpers so the workspace preview and main diff panel stay in sync

## Checklist
- [x] Surface changed files from thread turn diff summaries in the workspace explorer
- [x] Show per-file change badges or stats in the file tree
- [x] Let users jump from a file in the workspace panel to the file-specific diff view
- [x] Refresh the workspace diff state as new turn diff summaries arrive
- [x] Keep the diff presentation aligned with the current diff panel behavior
- [x] Add focused tests for diff aggregation and route search behavior
- [ ] Manual local verification

## Checks
- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `cd apps/web && bun run test -- workspaceAgentDiffs diffRouteSearch`
- [x] `bun run dev -- --no-browser` smoke start (`http://localhost:5734/`, `http://localhost:13774/`)